### PR TITLE
Bug 1338495 - Increase maximum partition fetch size

### DIFF
--- a/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
+++ b/src/main/scala/com/mozilla/telemetry/streaming/ErrorAggregator.scala
@@ -196,6 +196,7 @@ object ErrorAggregator {
       .readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", opts.kafkaBroker())
+      .option("kafka.max.partition.fetch.bytes", 8 * 1024 * 1024) // 8MB
       .option("subscribe", "telemetry")
       .option("startingOffsets", "latest")
       .load()


### PR DESCRIPTION
The kafka consumer has a setting that limits the maximum amount of data
per-partition that can be fetched from the server. This must be higher
than the maximum size of a ping, otherwise the job will raise an error.
The 8MB value was found empirically, we may have to further tune it in
the future.